### PR TITLE
Define something for SIGRTMIN so the compile will work on OS X.

### DIFF
--- a/src/plugins/select/cray/select_cray.c
+++ b/src/plugins/select/cray/select_cray.c
@@ -84,6 +84,13 @@ int switch_record_cnt;
 slurmdb_cluster_rec_t *working_cluster_rec = NULL;
 #endif
 
+/*
+ * SIGRTMIN isn't defined on osx, so lets keep it above the signals in use.
+ */
+#if !defined (SIGRTMIN) && defined (__APPLE__)
+#  define SIGRTMIN SIGUSR2+1
+#endif
+
 /* All current (2011) XT/XE installations have a maximum dimension of 3,
  * smaller systems deploy a 2D Torus which has no connectivity in
  * X-dimension.  Just incase SYSTEM_DIMENSIONS is ever set to 2


### PR DESCRIPTION
Since RT sigs don't exist on osx (even though they're POSIX), define the min RT sig to be above the current highest (SIGUSR2) so things will compile anyway. RT sigs are only used for alps integration anyway (which isn't going to be necessary on osx).
