### PR TITLE
Turn off opaque ncurses structs for OS X 10.6.

### DIFF
--- a/src/plugins/select/cray/select_cray.c
+++ b/src/plugins/select/cray/select_cray.c
@@ -84,6 +84,13 @@ int switch_record_cnt;
 slurmdb_cluster_rec_t *working_cluster_rec = NULL;
 #endif
 
+/*
+ * SIGRTMIN isn't defined on osx, so lets keep it above the signals in use.
+ */
+#if !defined (SIGRTMIN) && defined (__APPLE__)
+#  define SIGRTMIN SIGUSR2+1
+#endif
+
 /* All current (2011) XT/XE installations have a maximum dimension of 3,
  * smaller systems deploy a 2D Torus which has no connectivity in
  * X-dimension.  Just incase SYSTEM_DIMENSIONS is ever set to 2

--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -8151,10 +8151,10 @@ kill_job_on_node(uint32_t job_id, struct job_record *job_ptr,
 		kill_req->select_jobinfo =
 			select_g_select_jobinfo_copy(job_ptr->select_jobinfo);
 		kill_req->job_state = job_ptr->job_state;
+		kill_req->spank_job_env = xduparray(job_ptr->spank_job_env_size,
+			job_ptr->spank_job_env);
+		kill_req->spank_job_env_size = job_ptr->spank_job_env_size;
 	}
-	kill_req->spank_job_env = xduparray(job_ptr->spank_job_env_size,
-					    job_ptr->spank_job_env);
-	kill_req->spank_job_env_size = job_ptr->spank_job_env_size;
 
 	agent_info = xmalloc(sizeof(agent_arg_t));
 	agent_info->node_count	= 1;

--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -4088,7 +4088,7 @@ _write_data_array_to_file(char *file_name, char **data, uint32_t size)
 		return ESLURM_WRITING_TO_FILE;
 	}
 
-	if (data == NULL)
+	if (data == NULL) {
 		close(fd);
 		return SLURM_SUCCESS;
 	}

--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -4089,7 +4089,9 @@ _write_data_array_to_file(char *file_name, char **data, uint32_t size)
 	}
 
 	if (data == NULL)
+		close(fd);
 		return SLURM_SUCCESS;
+	}
 
 	for (i = 0; i < size; i++) {
 		nwrite = strlen(data[i]) + 1;
@@ -4233,6 +4235,7 @@ _read_data_array_from_file(char *file_name, char ***data, uint32_t * size,
 	if (rec_cnt == 0) {
 		*data = NULL;
 		*size = 0;
+		close(fd);
 		return;
 	}
 

--- a/src/slurmctld/power_save.c
+++ b/src/slurmctld/power_save.c
@@ -298,7 +298,7 @@ static pid_t _run_prog(char *prog, char *arg)
 	if (prog == NULL)	/* disabled, useful for testing */
 		return -1;
 
-	strncpy(program, prog, sizeof(program));
+	strncpy(program, prog, sizeof(program)-1);
 	pname = strrchr(program, '/');
 	if (pname == NULL)
 		pname = program;

--- a/src/slurmctld/trigger_mgr.c
+++ b/src/slurmctld/trigger_mgr.c
@@ -1425,7 +1425,7 @@ static void _trigger_run_program(trig_mgr_info_t *trig_in)
 
 	if (!_validate_trigger(trig_in))
 		return;
-	strncpy(program, trig_in->program, sizeof(program));
+	strncpy(program, trig_in->program, sizeof(program)-1);
 	pname = strrchr(program, '/');
 	if (pname == NULL)
 		pname = program;

--- a/src/slurmd/slurmd/read_proc.c
+++ b/src/slurmd/slurmd/read_proc.c
@@ -325,6 +325,7 @@ read_proc()
 				} 
 				if (sess_free == NULL) {
 					error ("read_proc: Internal error");
+					closedir(proc_fs);
 					return EINVAL;
 				} 
 			} 

--- a/src/slurmdbd/proc_req.c
+++ b/src/slurmdbd/proc_req.c
@@ -1004,7 +1004,7 @@ static int _cluster_cpus(slurmdbd_conn_t *slurmdbd_conn,
 		rc = SLURM_ERROR;
 	}
 end_it:
-	if (rc == SLURM_SUCCESS)
+	if (rc == SLURM_SUCCESS && cluster_cpus_msg)
 		slurmdbd_conn->cluster_cpus = cluster_cpus_msg->cpu_count;
 
 	slurmdbd_free_cluster_cpus_msg(cluster_cpus_msg);
@@ -2789,7 +2789,7 @@ static int   _register_ctld(slurmdbd_conn_t *slurmdbd_conn,
 
 end_it:
 
-	if (rc == SLURM_SUCCESS)
+	if (rc == SLURM_SUCCESS && register_ctld_msg)
 		slurmdbd_conn->ctld_port = register_ctld_msg->port;
 
 	slurmdbd_free_register_ctld_msg(register_ctld_msg);

--- a/src/smap/smap.h
+++ b/src/smap/smap.h
@@ -62,6 +62,15 @@
 #  include "src/common/getopt.h"
 #endif
 
+/*
+ * The following define is necessary for OS X 10.6. The apple supplied
+ * ncurses.h sets NCURSES_OPAQUE to 1 and then we can't get to the WINDOW
+ * flags.
+ */
+#if defined(__APPLE__)
+#  define NCURSES_OPAQUE 0
+#endif
+
 #if HAVE_CURSES_H
 #  include <curses.h>
 #endif


### PR DESCRIPTION
Starting with OS X 10.6, apple set NCURSES_OPAQUE to 1. This will prevent accessing the internals of ncurses structs. With it turned on, the compiler can not dereference various attributes in a WINDOW struct and this will result in a compile time error. A specific example is accessing the _maxx and _maxy of grid_win in smap.c.
