### PR TITLE
Prevent opaque ncurses WINDOW struct on OS X 10.6.

### DIFF
--- a/src/smap/smap.h
+++ b/src/smap/smap.h
@@ -62,6 +62,15 @@
 #  include "src/common/getopt.h"
 #endif
 
+/*
+ * The following define is necessary for OS X 10.6. The apple supplied
+ * ncurses.h sets NCURSES_OPAQUE to 1 and then we can't get to the WINDOW
+ * flags.
+ */
+#if defined(__APPLE__)
+#  define NCURSES_OPAQUE 0
+#endif
+
 #if HAVE_CURSES_H
 #  include <curses.h>
 #endif


### PR DESCRIPTION
Here's another one to work towards things compiling on osx. This might also apply to other systems that might set this as the default, but google doesn't seem to give any examples, so I just wrapped it in the **APPLE** for now.

Just an fyi, I'm running Mac OS X 10.6.7 (Darwin xxxx 10.7.0 Darwin Kernel Version 10.7.0: Sat Jan 29 15:16:10 PST 2011; root:xnu-1504.9.37~1/RELEASE_X86_64 x86_64).
