### PR TITLE
Fix for ld not able to inline on OS X 10.6.

### DIFF
--- a/src/common/slurm_protocol_defs.c
+++ b/src/common/slurm_protocol_defs.c
@@ -2188,7 +2188,7 @@ inline void slurm_free_shares_response_msg(shares_response_msg_t *msg)
 	}
 }
 
-inline void slurm_destroy_priority_factors_object(void *object)
+void slurm_destroy_priority_factors_object(void *object)
 {
 	priority_factors_object_t *obj_ptr =
 		(priority_factors_object_t *)object;

--- a/src/common/slurm_protocol_defs.h
+++ b/src/common/slurm_protocol_defs.h
@@ -981,7 +981,7 @@ inline void slurm_free_set_debug_level_msg(set_debug_level_msg_t *msg);
 inline void slurm_destroy_association_shares_object(void *object);
 inline void slurm_free_shares_request_msg(shares_request_msg_t *msg);
 inline void slurm_free_shares_response_msg(shares_response_msg_t *msg);
-inline void slurm_destroy_priority_factors_object(void *object);
+extern inline void slurm_destroy_priority_factors_object(void *object);
 inline void slurm_free_priority_factors_request_msg(
 	priority_factors_request_msg_t *msg);
 inline void slurm_free_priority_factors_response_msg(


### PR DESCRIPTION
Since the multifactor plugin uses this function, we need a copy of it in a library. So, we define it in the library file as non-inlined and in the header as extern inline so it's available for inlining when it's possible and in the library for when it's not.

Although this does fix the issue (preventing compile), I'm not quite sure it's the right path. If it is the right path, should the other inline functions be placed in the lib as well?
