### PR TITLE
Small AllowGroups document change

### DIFF
--- a/doc/man/man5/slurm.conf.5
+++ b/doc/man/man5/slurm.conf.5
@@ -2481,7 +2481,7 @@ The default value is "ALL".
 
 .TP
 \fBAllowGroups\fR
-Comma separated list of group IDs which may execute jobs in the partition.
+Comma separated list of group names which may execute jobs in the partition.
 If at least one group associated with the user attempting to execute the
 job is in AllowGroups, he will be permitted to use this partition.
 Jobs executed as user root can use any partition without regard to


### PR DESCRIPTION
that the gid should be used but in practice this actually requries the
group name not that gid. this should be made clear to save the
headaches that i got for this.
