### PR TITLE
Submit dir fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 This file describes changes in recent versions of SLURM. It primarily
 documents those changes that are of interest to users and admins.
 
+* Changes in SLURM 2.3.3-1.5chaos
+=================================
+ -- Changed SchedMD references in man and web pages back to LLNL
+ -- Fixed the setting of SLURM_SUBMIT_DIR for jobs submitted by Moab (BZ#1467)
+
 * Changes in SLURM 2.3.3-1.4chaos
 =================================
  -- Fix crash in slurmd on missing plugstack.conf (BZ#1441)

--- a/src/common/env.c
+++ b/src/common/env.c
@@ -1682,6 +1682,13 @@ char **env_array_from_file(const char *fname)
 		if (_env_array_entry_splitter(ptr, name, sizeof(name),
 					      value, ENV_BUFSIZE) &&
 		    (!_discard_env(name, value))) {
+			/*
+			 * Unset the SLURM_SUBMIT_DIR if it is defined so
+			 * that this new value does not get overwritten
+			 * in the subsequent call to env_array_merge().
+			 */
+			if (strcmp(name, "SLURM_SUBMIT_DIR") == 0)
+				unsetenv(name);
 			env_array_overwrite(&env, name, value);
 		}
 	}


### PR DESCRIPTION
Fixed the sbatch --export-file logic to use the SLURM_SUBMIT_DIR value read
from the file descriptor and not the directory from which sbatch was executed.
