### PR TITLE
Env var fix

### DIFF
--- a/src/sbatch/opt.c
+++ b/src/sbatch/opt.c
@@ -2127,6 +2127,13 @@ static bool _opt_verify(void)
 	bool verified = true;
 	char *dist = NULL, *lllp_dist = NULL;
 
+	/*
+	 * if the environment is coming from a file, the
+	 * environment at execution startup, must be unset.
+	 */
+	if (opt.export_file != NULL)
+		env_unset_environment();
+
 	if (opt.quiet && opt.verbose) {
 		error ("don't specify both --verbose (-v) and --quiet (-Q)");
 		verified = false;

--- a/src/sbatch/sbatch.c
+++ b/src/sbatch/sbatch.c
@@ -137,13 +137,6 @@ int main(int argc, char *argv[])
 		(void) _set_rlimit_env();
 	}
 
-	/*
-	 * if the environment is coming from a file, the
-	 * environment at execution startup, must be unset.
-	 */
-	if (opt.export_file != NULL)
-		env_unset_environment();
-
 	_set_prio_process_env();
 	_set_spank_env();
 	_set_submit_dir_env();


### PR DESCRIPTION
Moved up the env_unset_environment() call in sbatch to allow env variables such
as SLURM_JOB_NAME to survive.
