### PR TITLE
Wiki2 job record fix

### DIFF
--- a/src/plugins/sched/wiki2/get_jobs.c
+++ b/src/plugins/sched/wiki2/get_jobs.c
@@ -326,7 +326,7 @@ static char *	_dump_job(struct job_record *job_ptr, time_t update_time)
 
 	if (!IS_JOB_FINISHED(job_ptr) && job_ptr->details &&
 	    job_ptr->details->work_dir) {
-		snprintf(tmp, sizeof(tmp), "IWD=%s;",
+		snprintf(tmp, sizeof(tmp), "IWD=\"%s\";",
 			 job_ptr->details->work_dir);
 		xstrcat(buf, tmp);
 	}
@@ -335,12 +335,12 @@ static char *	_dump_job(struct job_record *job_ptr, time_t update_time)
 		xstrcat(buf, "FLAGS=INTERACTIVE;");
 
 	if (job_ptr->gres) {
-		snprintf(tmp, sizeof(tmp),"GRES=%s;", job_ptr->gres);
+		snprintf(tmp, sizeof(tmp),"GRES=\"%s\";", job_ptr->gres);
 		xstrcat(buf, tmp);
 	}
 
 	if (job_ptr->wckey) {
-		snprintf(tmp, sizeof(tmp),"WCKEY=%s;", job_ptr->wckey);
+		snprintf(tmp, sizeof(tmp),"WCKEY=\"%s\";", job_ptr->wckey);
 		xstrcat(buf, tmp);
 	}
 
@@ -368,7 +368,7 @@ static char *	_dump_job(struct job_record *job_ptr, time_t update_time)
 	else
 		pname = "UNKNOWN";	/* should never see this */
 	snprintf(tmp, sizeof(tmp),
-		"QUEUETIME=%u;STARTTIME=%u;RCLASS=%s;",
+		"QUEUETIME=%u;STARTTIME=%u;RCLASS=\"%s\";",
 		_get_job_submit_time(job_ptr),
 		(uint32_t) job_ptr->start_time, pname);
 	xstrcat(buf, tmp);
@@ -402,7 +402,7 @@ static char *	_dump_job(struct job_record *job_ptr, time_t update_time)
 
 	if (job_ptr->account) {
 		snprintf(tmp, sizeof(tmp),
-			"ACCOUNT=%s;", job_ptr->account);
+			"ACCOUNT=\"%s\";", job_ptr->account);
 		xstrcat(buf, tmp);
 	}
 


### PR DESCRIPTION
Fix sched/wiki2 to support job account name, gres, partition name,
wckey, or working directory that contains "#" (a job record
separator).  Without this patch, the parsing will probably stop once
reaching the "#".

This is the same commit as the April 16, 2012 commit 6cd20848dc to the
slurm-2.3 branch.
