### PR TITLE
Priority boost fix

### DIFF
--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -6307,8 +6307,10 @@ extern void sync_job_priorities(void)
 		return;
 
 	job_iterator = list_iterator_create(job_list);
-	while ((job_ptr = (struct job_record *) list_next(job_iterator)))
-		job_ptr->priority += prio_boost;
+	while ((job_ptr = (struct job_record *) list_next(job_iterator))) {
+		if (job_ptr->priority)
+			job_ptr->priority += prio_boost;
+	}
 	list_iterator_destroy(job_iterator);
 	lowest_prio += prio_boost;
 }


### PR DESCRIPTION
This is a fix to the sync_job_priorities() function to prevent priority
boosting for held jobs (priority ==0) when the slurmctld is restarted.

See: commit 8b14f3880d0 on Jan 19, 2011
When restarting slurmctld with priority/basic, increment all job priorities
