### PR TITLE
Fix for dependent job prioritization bug

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ documents those changes that are of interest to users and admins.
 ========================
  -- Prevent background salloc disconnecting terminal at termination. Patch by
     Don Albert, Bull.
+ -- Fix for HTC with --reboot on BG/P systems
+ -- Recalculate job priority of a dependent job when all dependencies are
+    released.
 
 * Changes in SLURM 2.2.7
 ========================

--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -7750,6 +7750,7 @@ extern bool job_independent(struct job_record *job_ptr, int will_run)
 	struct job_details *detail_ptr = job_ptr->details;
 	time_t now = time(NULL);
 	int depend_rc;
+	bool independent = false;
 
 	/* Test dependencies first so we can cancel jobs before dependent
 	 * job records get purged (e.g. afterok, afternotok) */
@@ -7789,11 +7790,14 @@ extern bool job_independent(struct job_record *job_ptr, int will_run)
 	/* Job is eligible to start now */
 	if (job_ptr->state_reason == WAIT_DEPENDENCY) {
 		job_ptr->state_reason = WAIT_NO_REASON;
+		independent = true;
 		xfree(job_ptr->state_desc);
 	}
 	if ((detail_ptr && (detail_ptr->begin_time == 0) &&
 	    (job_ptr->priority != 0))) {
 		detail_ptr->begin_time = now;
+		if (independent)
+			_set_job_prio(job_ptr);
 	} else if (job_ptr->state_reason == WAIT_TIME) {
 		job_ptr->state_reason = WAIT_NO_REASON;
 		xfree(job_ptr->state_desc);


### PR DESCRIPTION
SLURM would schedule lower priority jobs to run instead of higher
priority, dependent jobs once their dependencies were satisfied.  This
happened because dependent jobs still have a priority of 1 when the
job queue is sorted in the schedule() function.  The fix forces
dependent jobs to have their priority updated when their dependencies
are satisfied.
