### PR TITLE
Add SUBMITHOST to job state passed to Moab vial sched/wiki2. 

### DIFF
--- a/src/plugins/sched/wiki2/get_jobs.c
+++ b/src/plugins/sched/wiki2/get_jobs.c
@@ -339,6 +339,11 @@ static char *	_dump_job(struct job_record *job_ptr, time_t update_time)
 		xstrcat(buf, tmp);
 	}
 
+	if (job_ptr->resp_host) {
+		snprintf(tmp, sizeof(tmp),"SUBMITHOST=\"%s\";", job_ptr->resp_host);
+		xstrcat(buf, tmp);
+	}
+
 	if (job_ptr->wckey) {
 		snprintf(tmp, sizeof(tmp),"WCKEY=\"%s\";", job_ptr->wckey);
 		xstrcat(buf, tmp);


### PR DESCRIPTION
Backport from schedmd slurm-2.4 branch. Add SUBMITHOST to job state passed to Moab vial sched/wiki2.

SchedMD/slurm commit hash = b7ab18cda9194b231ba066eebaa4f2c05358786f
