### PR TITLE
Munge socket

### DIFF
--- a/doc/man/man5/slurm.conf.5
+++ b/doc/man/man5/slurm.conf.5
@@ -831,7 +831,7 @@ Used to identify ports used by OpenMPI only and the input format is
 
 .TP
 \fBMungeSocket\fR
-Used for Munge authentication when a socket other than the defaault is
+Used for Munge authentication when a socket other than the default is
 needed. In the case of use with A Moab slaveless grid, authentication can
 be configured to use a MUNGE daemon specifically configured to provide
 authentication between clusters, while the default MUNGE daemon provides

--- a/doc/man/man5/slurm.conf.5
+++ b/doc/man/man5/slurm.conf.5
@@ -835,7 +835,8 @@ Used for Munge authentication when a socket other than the defaault is
 needed. In the case of use with A Moab slaveless grid, authentication can
 be configured to use a MUNGE daemon specifically configured to provide
 authentication between clusters, while the default MUNGE daemon provides
-authentication within a cluster. The default value is NULL.
+authentication within a cluster. If not set, the default munge socket is
+used.
 
 .TP
 \fBOverTimeLimit\fR

--- a/doc/man/man5/slurm.conf.5
+++ b/doc/man/man5/slurm.conf.5
@@ -830,6 +830,14 @@ Used to identify ports used by OpenMPI only and the input format is
 "ports=12000\-12999" to identify a range of communication ports to be used.
 
 .TP
+\fBMungeSocket\fR
+Used for Munge authentication when a socket other than the defaault is
+needed. In the case of use with A Moab slaveless grid, authentication can
+be configured to use a MUNGE daemon specifically configured to provide
+authentication between clusters, while the default MUNGE daemon provides
+authentication within a cluster. The default value is NULL.
+
+.TP
 \fBOverTimeLimit\fR
 Number of minutes by which a job can exceed its time limit before
 being canceled.

--- a/slurm/slurm.h.in
+++ b/slurm/slurm.h.in
@@ -1828,6 +1828,7 @@ typedef struct slurm_ctl_conf {
 				 * purged from in memory records */
 	char *mpi_default;	/* Default version of MPI in use */
 	char *mpi_params;	/* MPI parameters */
+	char *munge_socket;	/* munge socket to use */
 	uint16_t msg_timeout;	/* message timeout */
 	uint32_t next_job_id;	/* next slurm generated job_id to assign */
 	char *node_prefix;      /* prefix of nodes in partition, only set in

--- a/slurm/slurm.h.in
+++ b/slurm/slurm.h.in
@@ -1828,8 +1828,8 @@ typedef struct slurm_ctl_conf {
 				 * purged from in memory records */
 	char *mpi_default;	/* Default version of MPI in use */
 	char *mpi_params;	/* MPI parameters */
-	char *munge_socket;	/* munge socket to use */
 	uint16_t msg_timeout;	/* message timeout */
+	char *munge_socket;	/* munge socket to use */
 	uint32_t next_job_id;	/* next slurm generated job_id to assign */
 	char *node_prefix;      /* prefix of nodes in partition, only set in
 				   bluegene clusters NULL otherwise */

--- a/src/common/read_config.c
+++ b/src/common/read_config.c
@@ -215,6 +215,7 @@ s_p_options_t slurm_conf_options[] = {
 	{"MinJobAge", S_P_UINT16},
 	{"MpiDefault", S_P_STRING},
 	{"MpiParams", S_P_STRING},
+	{"MungeSocket", S_P_STRING},
 	{"OverTimeLimit", S_P_UINT16},
 	{"PluginDir", S_P_STRING},
 	{"PlugStackConfig", S_P_STRING},
@@ -1797,6 +1798,7 @@ free_slurm_conf (slurm_ctl_conf_t *ctl_conf_ptr, bool purge_node_hash)
 	xfree (ctl_conf_ptr->mail_prog);
 	xfree (ctl_conf_ptr->mpi_default);
 	xfree (ctl_conf_ptr->mpi_params);
+	xfree (ctl_conf_ptr->munge_socket);
 	xfree (ctl_conf_ptr->node_prefix);
 	xfree (ctl_conf_ptr->plugindir);
 	xfree (ctl_conf_ptr->plugstack);
@@ -1909,6 +1911,7 @@ init_slurm_conf (slurm_ctl_conf_t *ctl_conf_ptr)
 	ctl_conf_ptr->min_job_age		= (uint16_t) NO_VAL;
 	xfree (ctl_conf_ptr->mpi_default);
 	xfree (ctl_conf_ptr->mpi_params);
+	xfree (ctl_conf_ptr->munge_socket);
 	ctl_conf_ptr->msg_timeout		= (uint16_t) NO_VAL;
 	ctl_conf_ptr->next_job_id		= (uint32_t) NO_VAL;
 	xfree (ctl_conf_ptr->node_prefix);
@@ -2495,6 +2498,8 @@ _validate_and_set_defaults(slurm_ctl_conf_t *conf, s_p_hashtbl_t *hashtbl)
 		conf->mpi_default = xstrdup(DEFAULT_MPI_DEFAULT);
 
 	s_p_get_string(&conf->mpi_params, "MpiParams", hashtbl);
+
+	s_p_get_string(&conf->munge_socket, "MungeSocket", hashtbl);
 
 	if(!s_p_get_boolean((bool *)&conf->track_wckey,
 			    "TrackWCKey", hashtbl))


### PR DESCRIPTION
Added update to man page that Mark requested.

Modification to the slurm-2.3.3.chaos branch that adds a “MungeSocket” option to the slurm.conf file. When this is set, all of the slurmctlds and clients within a grid of clusters will communicate based on its value (which we’ll set to moab.socket.2) instead of the default munge socket.
