### PR TITLE
Fix parsing errors on new fields - WorkDir and ProcCnt.

### DIFF
--- a/src/plugins/jobcomp/filetxt/filetxt_jobcomp_process.c
+++ b/src/plugins/jobcomp/filetxt/filetxt_jobcomp_process.c
@@ -154,6 +154,10 @@ static jobcomp_job_rec_t *_parse_line(List job_info_list)
 			job->state = xstrdup(jobcomp_info->val);
 		} else if(!strcasecmp("Timelimit", jobcomp_info->name)) {
 			job->timelimit = xstrdup(jobcomp_info->val);
+		} else if(!strcasecmp("WorkDir", jobcomp_info->name)) {
+			; /* placeholder for future use. */
+		} else if(!strcasecmp("ProcCnt", jobcomp_info->name)) {
+			; /* placeholder for future use. */
 		}
 #ifdef HAVE_BG
 		else if(!strcasecmp("MaxProcs", jobcomp_info->name)) {


### PR DESCRIPTION
At some time in the past two items were added to the JOB_FORMAT
statement in jobcomp_filetxt.c, but  were never used elsewhere.
This was casuing errors in filetxt_jobcomp_process.c when it
attempted to parse them. A Check was added to allow, but ignore
them.
