### PR TITLE
Patch to fix perl api module node.c

### DIFF
--- a/contribs/perlapi/libslurm/perl/node.c
+++ b/contribs/perlapi/libslurm/perl/node.c
@@ -135,6 +135,8 @@ node_info_msg_to_hv(node_info_msg_t *node_info_msg, HV *hv)
 	/* record_count implied in node_array */
 	av = newAV();
 	for(i = 0; i < node_info_msg->record_count; i ++) {
+		if (!node_info_msg->node_array[i].name)
+			continue;
 		hv_info =newHV();
 		if (node_info_to_hv(node_info_msg->node_array + i,
 				    node_info_msg->node_scaling, hv_info) < 0) {


### PR DESCRIPTION
The perl api call to load_node will take an
argument, "SHOW_ALL", which will result in
returning all node names, even those in a
hidden partition. If called without an agrument
it should respond like the c api, and return all
a NULL node name for those nodes in the hidden
oartition.

However, the node.c module was returning a error
when encountering a NULL node name, this fix
checks for NULL and skips the record.

SchedMD is making the same mod.
