### PR TITLE
Stop rebuilding job's node completing list on reconfig

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 This file describes changes in recent versions of SLURM. It primarily
 documents those changes that are of interest to users and admins.
 
+* Changes in SLURM 2.3.3-1.15chaos
+==================================
+ -- Fix TOSS-1683: slurmctld errors for completing jobs after a logrotate
+
 * Changes in SLURM 2.3.3-1.14chaos
 ==================================
  -- Fix TOSS-1979: freezer cgroup directories remain after job completes.

--- a/src/slurmctld/read_config.c
+++ b/src/slurmctld/read_config.c
@@ -696,10 +696,6 @@ int read_slurm_conf(int recover, bool reconfig)
 	START_TIMER;
 
 	if (reconfig) {
-		/* in order to re-use job state information,
-		 * update nodes_completing string (based on node_bitmap) */
-		update_job_nodes_completing();
-
 		/* save node and partition states for reconfig RPC */
 		old_node_record_count = node_record_count;
 		old_node_table_ptr    = node_record_table_ptr;


### PR DESCRIPTION
Removed the call to update_job_nodes_completing() from read_slurm_conf().
Jobs stuck in completing will no longer have all of the nodes of the original
job added to the list of nodes stuck in completing when SIGHUP is sent to the
slurmctld or "scontrol reconfig" is invoked.
