### PR TITLE
Fix window size slicing

### DIFF
--- a/src/common/env.h
+++ b/src/common/env.h
@@ -71,8 +71,8 @@ typedef struct env_options {
 	pid_t task_pid;
 	char *sgtids;		/* global ranks array of integers */
 	uint16_t pty_port;	/* used to communicate window size changes */
-	uint8_t ws_col;		/* window size, columns */
-	uint8_t ws_row;		/* window size, row count */
+	uint16_t ws_col;	/* window size, columns */
+	uint16_t ws_row;	/* window size, row count */
 	char *ckpt_dir;		/* --ckpt-dir=                 */
 	uint16_t restart_cnt;	/* count of job restarts	*/
 	uint16_t batch_flag;	/* 1 if batch: queued job with script */

--- a/src/srun/srun_job.h
+++ b/src/srun/srun_job.h
@@ -112,8 +112,8 @@ typedef struct srun_job {
 	pthread_t pty_id;	/* pthread to communicate window size changes */
 	int pty_fd;		/* file to communicate window size changes */
 	uint16_t pty_port;	/* used to communicate window size changes */
-	uint8_t ws_col;		/* window size, columns */
-	uint8_t ws_row;		/* window size, row count */
+	uint16_t ws_col;	/* window size, columns */
+	uint16_t ws_row;	/* window size, row count */
 	slurm_step_ctx_t *step_ctx;
 	slurm_step_ctx_params_t ctx_params;
 } srun_job_t;


### PR DESCRIPTION
This fixes the, apparently accidental, slicing of the pty column and row fields when assigned into either env_t or srun_job_t.  As far as I can tell, neither of these are ever passed over the line.  The one place that does pass the row and column values across the line, in srun_pty, does so with the correct 2-byte size already, so it should not impact the protocol version.
