### PR TITLE
Add a reliable detection scheme for a target process being traced

### DIFF
--- a/src/common/jobacct_common.c
+++ b/src/common/jobacct_common.c
@@ -39,6 +39,8 @@
  *  Copyright (C) 2002 The Regents of the University of California.
 \*****************************************************************************/
 
+#include <sys/time.h>
+#include <sys/resource.h>
 #include "jobacct_common.h"
 
 /*

--- a/src/plugins/accounting_storage/filetxt/filetxt_jobacct_process.c
+++ b/src/plugins/accounting_storage/filetxt/filetxt_jobacct_process.c
@@ -43,6 +43,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 
 #include "src/common/xstring.h"
 #include "src/common/xmalloc.h"

--- a/src/salloc/salloc.c
+++ b/src/salloc/salloc.c
@@ -51,6 +51,8 @@
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 #include <termios.h>
 #include <time.h>
 #include <unistd.h>

--- a/src/sbatch/sbatch.c
+++ b/src/sbatch/sbatch.c
@@ -48,6 +48,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/param.h>               /* MAXPATHLEN */
+#include <sys/time.h>
+#include <sys/resource.h>
 #include <fcntl.h>
 
 #include "slurm/slurm.h"

--- a/src/slurmd/slurmstepd/pdebug.c
+++ b/src/slurmd/slurmstepd/pdebug.c
@@ -39,12 +39,10 @@
 #include "pdebug.h"
 
 #include <fcntl.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef HAVE_LINUX_SCHED_H
-#  include <linux/sched.h>
-#endif
 
 /*
  * Prepare task for parallel debugger attach
@@ -140,38 +138,44 @@ pdebug_stop_current(slurmd_job_t *job)
 }
 
 /* Check if this PID should be woken for TotalView partitial attach */
+static int _being_traced(pid_t pid)
+{
+    FILE *fp = NULL;
+    size_t n = 0;
+    int tracer_id = 0;
+    char *match = NULL;
+    char buf[2048] = {0};
+    char sp[PATH_MAX] = {0};
+
+    if (snprintf(sp, PATH_MAX, "/proc/%lu/status", (unsigned long)pid) == -1)
+        return -1;
+    if ( (fp = fopen((const char *)sp, "r")) == NULL )
+        return -1;
+    n = fread(buf, 1, sizeof(buf), fp);
+    fclose(fp);
+    if (n == 0 || n == sizeof (buf))
+        return -1;
+    if ( (match = strstr(buf, "TracerPid:")) == NULL)
+        return -1;
+    if (sscanf(match, "TracerPid:\t%d", &tracer_id) == EOF)
+        return -1;
+    return tracer_id;
+}
+
 static bool _pid_to_wake(pid_t pid)
 {
-#ifdef CLONE_PTRACE
-	char proc_stat[1024], proc_name[22], state[1], *str_ptr;
-	int len, proc_fd, ppid, pgrp, session, tty, tpgid;
-	long unsigned flags;
-
-	sprintf (proc_name, "/proc/%d/stat", (int) pid);
-	if ((proc_fd = open(proc_name, O_RDONLY, 0)) == -1)
-		return false;  /* process is now gone */
-	len = read(proc_fd, proc_stat, sizeof(proc_stat));
-	close(proc_fd);
-	if (len < 14)
-		return false;
-	/* skip over "PID (CMD) " */
-	if ((str_ptr = (char *)strrchr(proc_stat, ')')) == NULL)
-		return false;
-	if (sscanf(str_ptr + 2, 
-		   "%c %d %d %d %d %d %lu ", 
-		   state, &ppid, &pgrp, &session, &tty, &tpgid, &flags) != 7)
-		return false;
-	if ((flags & CLONE_PTRACE) == 0)
-		return true;
-	return false;
-#else
-	int status;
-
-	waitpid(pid, &status, (WUNTRACED | WNOHANG));
-	if (WIFSTOPPED(status))
-		return true;
-	return false;
-#endif
+    int rc = 0;
+    if ( (rc = _being_traced(pid)) == -1) {
+        /* If an error occurred (e.g., /proc FS doesn't exist
+         * or TracerPid field doesn't exist, it is better to wake
+         * up the target process -- at the expense of potential
+         * side effects on the debugger.
+         */
+        debug("_pid_to_wake(%lu): %m\n", (unsigned long) pid);
+        errno = 0;
+        rc = 0;
+    }
+    return (rc == 0) ? true : false;
 }
 
 /*
@@ -186,7 +190,7 @@ void pdebug_wake_process(slurmd_job_t *job, pid_t pid)
 			else
 				debug("woke pid %lu", (unsigned long) pid);
 		} else {
-			debug("pid %lu not stopped", (unsigned long) pid);
+			debug("pid %lu not stopped or being traced", (unsigned long) pid);
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes issues with MPIR_partial_attach_ok support within SLURM. Along the way, I found SLURM doesn't build with TOSS3 with the default gcc compiler (4.8.5) and `sys/resource.h` needed headers are included. 
