### PR TITLE
Fix/small msg limit

### DIFF
--- a/src/common/pack.c
+++ b/src/common/pack.c
@@ -60,8 +60,8 @@
  * memory allocation error due to array or buffer sizes that are
  * unreasonably large. Increase this limits as needed. */
 #define MAX_PACK_ARRAY_LEN	(128 * 1024)
-#define MAX_PACK_MEM_LEN	(16 * 1024 * 1024)
-#define MAX_PACK_STR_LEN	(16 * 1024 * 1024)
+#define MAX_PACK_MEM_LEN	(1024 * 1024 * 1024)
+#define MAX_PACK_STR_LEN	(1024 * 1024 * 1024)
 
 /*
  * Define slurm-specific aliases for use by plugins, see slurm_xlator.h

--- a/src/common/slurm_protocol_socket_implementation.c
+++ b/src/common/slurm_protocol_socket_implementation.c
@@ -88,7 +88,7 @@
  *  Maximum message size. Messages larger than this value (in bytes)
  *  will not be received.
  */
-#define MAX_MSG_SIZE     (128*1024*1024)
+#define MAX_MSG_SIZE     (1024*1024*1024)
 
 /****************************************************************
  * MIDDLE LAYER MSG FUNCTIONS

--- a/src/plugins/mpi/pmi2/tree.c
+++ b/src/plugins/mpi/pmi2/tree.c
@@ -717,7 +717,7 @@ tree_msg_to_stepds(hostlist_t hl, uint32_t len, char *data)
 							ret_data_info->data);
 			if (temp_rc){
 				rc = temp_rc;
-				error("tree_msg_to_stepds: host=%s, rc = %d",
+				debug("tree_msg_to_stepds: host=%s, rc = %d",
 				      ret_data_info->node_name, rc);
 			} else {
 				hostlist_delete_host(hl, ret_data_info->node_name);


### PR DESCRIPTION
At large scale, the PMI key/value exchange messages were growing larger than the 16MB limit this version of SLURM allows.  This patch ups that limit to 1GB.  It also converts a particular error message to a debug message when a stepd tries to connect to another stepd on another node which has yet to open its connection.
