### PR TITLE
Jira toss 3325

### DIFF
--- a/META
+++ b/META
@@ -11,7 +11,7 @@
   Minor:	3
   Micro:	3
   Version:	2.3.3
-  Release:	1.24chaos
+  Release:	1.25chaos
 ##
 #  When changing API_CURRENT update src/common/slurm_protocol_common.h
 #  with a new SLURM_PROTOCOL_VERSION signifing the old one and the version

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 This file describes changes in recent versions of SLURM. It primarily
 documents those changes that are of interest to users and admins.
 
+* Changes in SLURM 2.3.3-1.25chaos
+==================================
+ -- Remove pmi and pmi2 libtool archive files from devel package
+    Address Jira ticket TOSS-3325
+
 * Changes in SLURM 2.3.3-1.24chaos
 ==================================
  -- Increase max message to 1GB to support pmi2 scalability.

--- a/slurm.spec
+++ b/slurm.spec
@@ -429,8 +429,8 @@ install -D -m755 etc/slurm.epilog.clean ${RPM_BUILD_ROOT}%{_sysconfdir}/slurm.ep
 install -D -m755 contribs/sjstat ${RPM_BUILD_ROOT}%{_bindir}/sjstat
 
 # Delete unpackaged files:
-rm -f $RPM_BUILD_ROOT/%{_libdir}/libpmi.a
-rm -f $RPM_BUILD_ROOT/%{_libdir}/libpmi2.a
+rm -f $RPM_BUILD_ROOT/%{_libdir}/libpmi.{a,la}
+rm -f $RPM_BUILD_ROOT/%{_libdir}/libpmi2.{a,la}
 rm -f $RPM_BUILD_ROOT/%{_libdir}/libslurm.a
 rm -f $RPM_BUILD_ROOT/%{_libdir}/libslurmdb.a
 rm -f $RPM_BUILD_ROOT/%{_libdir}/slurm/*.{a,la}
@@ -612,8 +612,6 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root)
 %dir %attr(0755,root,root) %{_prefix}/include/slurm
 %{_prefix}/include/slurm/*
-%{_libdir}/libpmi.la
-%{_libdir}/libpmi2.la
 %{_libdir}/libslurm.la
 %{_libdir}/libslurmdb.la
 %{_mandir}/man3/slurm_*


### PR DESCRIPTION
Follows @adammoody 's recommendation in the TOSS-3325 Jira ticket to remove libpmi.la and libpmi2.la from slurm-devel rpm.
