### PR TITLE
Increase max tasks

### DIFF
--- a/META
+++ b/META
@@ -11,7 +11,7 @@
   Minor:	3
   Micro:	3
   Version:	2.3.3
-  Release:	1.26chaos
+  Release:	1.27chaos
 ##
 #  When changing API_CURRENT update src/common/slurm_protocol_common.h
 #  with a new SLURM_PROTOCOL_VERSION signifing the old one and the version

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 This file describes changes in recent versions of SLURM. It primarily
 documents those changes that are of interest to users and admins.
 
+* Changes in SLURM 2.3.3-1.27chaos
+==================================
+ -- Increase the compiled-in MAX_TASKS_PER_NODE from 128 to 288 to support
+    increased core counts of CTS-1 systems.
+    Addresses Jira ticket TOSS-3371
+
 * Changes in SLURM 2.3.3-1.26chaos
 ==================================
  -- This is to enable procs to call PMIX_Ring when started as a single

--- a/slurm/slurm.h.in
+++ b/slurm/slurm.h.in
@@ -214,7 +214,7 @@ typedef struct sbcast_cred sbcast_cred_t;		/* opaque data type */
 /* eg. the maximum count of nodes any job may use in some partition */
 #define	INFINITE (0xffffffff)
 #define NO_VAL	 (0xfffffffe)
-#define MAX_TASKS_PER_NODE 128
+#define MAX_TASKS_PER_NODE 288
 
 /* Job step ID of batch scripts */
 #define SLURM_BATCH_SCRIPT (0xfffffffe)


### PR DESCRIPTION
Increase the compiled-in MAX_TASKS_PER_NODE from 128 to 288 to support increased core counts of CTS-1 systems.

Address Jira ticket TOSS-3371
